### PR TITLE
By default ignore 'ActionDispatch::Http::MimeNegotiation::InvalidType'

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -23,6 +23,8 @@ module Honeybadger
                       'ActionController::ParameterMissing',
                       'ActiveRecord::RecordNotFound',
                       'ActionController::UnknownAction',
+                      'ActionDispatch::Http::MimeNegotiation::InvalidType',
+                      git@github.com:jrochkind/honeybadger-ruby.git
                       'Rack::QueryParser::ParameterTypeError',
                       'Rack::QueryParser::InvalidParameterError',
                       'CGI::Session::CookieStore::TamperedWithCookie',


### PR DESCRIPTION
If a user-agent sends an Accept or Content-Type header with a mal-formed mime-type, then Rails raises. this happens in my app a lot as a result of what seems to be security vulnerability scanning, people sending Accept headers like `"../../../../../../../../../../etc/passwd{%00`

Rails is not vulnerable, everything is fine, but it raises. And Honeybadger than catches and reports.

Prior to Rals 6.1, the exception class was non-specific so it was hard to ignore/filter. But Rails 6.1 introduces an exception class just for this. Honeybadger should by default ignore it, it fits in with the other Rails stuff Honeybadger ignores by default.


**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Add an entry to the CHANGELOG.